### PR TITLE
Improve Pages base path handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,42 +39,48 @@ const queryClient = new QueryClient({
   },
 });
 
+const basename =
+  import.meta.env.BASE_URL === "/"
+    ? undefined
+    : import.meta.env.BASE_URL.replace(/\/+$/, "");
+
 const App = () => (
   <HelmetProvider>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <InterestFormProvider>
           <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter 
-            future={{
-              v7_startTransition: true,
-              v7_relativeSplatPath: true
-            }}
-          >
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/plan-selection" element={<PlanSelection />} />
-              <Route path="/about" element={<About />} />
-              <Route path="/how-it-works" element={<HowItWorks />} />
-              <Route path="/pricing" element={<PricingPage />} />
-              <Route path="/faq" element={<FAQ />} />
-              <Route path="/blog" element={<Blog />} />
-              <Route path="/blog/:slug" element={<BlogPost />} />
-              <Route path="/contact" element={<Contact />} />
-              <Route path="/thank-you" element={<ThankYou />} />
-              <Route path="/auth/callback" element={<AuthCallback />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-          <OnboardingRedirector />
-          <AutoInterestForm />
-          </BrowserRouter>
-        </TooltipProvider>
-      </InterestFormProvider>
-    </AuthProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter
+              basename={basename}
+              future={{
+                v7_startTransition: true,
+                v7_relativeSplatPath: true,
+              }}
+            >
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/plan-selection" element={<PlanSelection />} />
+                <Route path="/about" element={<About />} />
+                <Route path="/how-it-works" element={<HowItWorks />} />
+                <Route path="/pricing" element={<PricingPage />} />
+                <Route path="/faq" element={<FAQ />} />
+                <Route path="/blog" element={<Blog />} />
+                <Route path="/blog/:slug" element={<BlogPost />} />
+                <Route path="/contact" element={<Contact />} />
+                <Route path="/thank-you" element={<ThankYou />} />
+                <Route path="/auth/callback" element={<AuthCallback />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+              <OnboardingRedirector />
+              <AutoInterestForm />
+            </BrowserRouter>
+          </TooltipProvider>
+        </InterestFormProvider>
+      </AuthProvider>
     </QueryClientProvider>
   </HelmetProvider>
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,14 +3,39 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
-// ---------- CHANGE THIS to your repo name ----------
-const REPO = "career-climb-automagic";
-// ---------------------------------------------------
+// Normalize a custom base path coming from the workflow. We allow a bare
+// slash for root-hosted sites (custom domain / `username.github.io`) and make
+// sure everything else has a single leading/trailing slash so Vite behaves.
+const normalizeBase = (base?: string) => {
+  if (!base) return undefined;
+  const trimmed = base.trim();
+  if (!trimmed) return undefined;
+  if (trimmed === "/") return "/";
+  const withoutSlashes = trimmed.replace(/^\/+|\/+$/g, "");
+  return withoutSlashes ? `/${withoutSlashes}/` : "/";
+};
+
+// Try to infer the repo name automatically for GitHub Pages deployments.
+// Falls back to the previous hard-coded value so local builds keep working.
+const repoSlug =
+  process.env.GITHUB_PAGES_REPO ??
+  process.env.GITHUB_REPOSITORY ??
+  "career-climb-automagic";
+
+const repoName = repoSlug.split("/").filter(Boolean).pop() ?? "career-climb-automagic";
+
+// GitHub Pages serves user/org sites (repo name ends with `.github.io`) from
+// the domain root, so they need a `/` base instead of `/<repo>/`.
+const defaultPagesBase = repoName.endsWith(".github.io")
+  ? "/"
+  : `/${repoName}/`;
+
+const envBase = normalizeBase(process.env.GITHUB_PAGES_BASE);
 
 export default defineConfig(({ mode }) => ({
   // ✅ Use a base path ONLY when building for GitHub Pages
   //    (we'll set GITHUB_PAGES=true in the workflow)
-  base: process.env.GITHUB_PAGES ? `/${REPO}/` : "/",
+  base: process.env.GITHUB_PAGES ? envBase ?? defaultPagesBase : "/",
 
   server: {
     host: "::",


### PR DESCRIPTION
## Summary
- normalize custom GitHub Pages base overrides so they always have the right slashes
- fall back to `/` for user/org Pages sites and allow explicit overrides via `GITHUB_PAGES_BASE`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb74ea21c83318007bd42b4799b1e