### PR TITLE
Streamline sign-in flow routing

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/hooks/useSignInFlow.ts
+++ b/src/hooks/useSignInFlow.ts
@@ -41,30 +41,8 @@ export const useSignInFlow = () => {
 
       if (profileError) throw profileError;
 
-      // Check plan_selections as fallback if profile doesn't exist or has no plan
-      if (!profile?.plan || profile.plan === 'free') {
-        const { data: planSelection } = await supabase
-          .from('plan_selections')
-          .select('selected_plan, status')
-          .eq('user_id', user.id)
-          .eq('status', 'completed')
-          .maybeSingle();
-
-        if (planSelection?.selected_plan && planSelection.selected_plan !== 'free') {
-          // Sync profile with plan selection
-          await supabase
-            .from('profiles')
-            .upsert({ 
-              id: user.id, 
-              email: user.email, 
-              plan: planSelection.selected_plan 
-            }, {
-              onConflict: 'id'
-            });
-          navigate('/dashboard');
-        } else {
-          navigate('/plan-selection');
-        }
+      if (!profile?.plan) {
+        navigate('/plan-selection');
       } else {
         navigate('/dashboard');
       }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -149,5 +150,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- simplify the sign-in flow to branch on interest form and profile plan status before routing
- replace deprecated lint rule violations by using type aliases and ES module plugin import

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdbc0ddcc08331a32a62aa4242b24c