### PR TITLE
Fix plan selection upsert conflict

### DIFF
--- a/src/pages/PlanSelection.tsx
+++ b/src/pages/PlanSelection.tsx
@@ -101,6 +101,8 @@ const PlanSelection = () => {
           selected_plan: planId,
           status: 'completed',
           selection_completed_at: new Date().toISOString()
+        }, {
+          onConflict: 'user_id'
         })
 
       if (planSelectionError) throw planSelectionError


### PR DESCRIPTION
## Summary
- ensure plan selection upserts resolve conflicts by user id to prevent duplicate key errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc234a470833188001a31210a3f91