### PR TITLE
Ensure resume uploads handle supported file types

### DIFF
--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -26,12 +26,19 @@ interface UserProfile {
   subscription_status?: string;
 }
 
+interface UserPreferences {
+  location: string | null;
+  job_title: string | null;
+  seniority_level: string | null;
+  job_type: string | null;
+}
+
 export const Sidebar = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
-  const [preferences, setPreferences] = useState<any>(null);
+  const [preferences, setPreferences] = useState<UserPreferences | null>(null);
 
   useEffect(() => {
     if (user) {
@@ -57,7 +64,7 @@ export const Sidebar = () => {
         .eq('user_id', user?.id)
         .maybeSingle();
 
-      setPreferences(preferencesData);
+      setPreferences(preferencesData ?? null);
     } catch (error) {
       console.error('Error fetching profile:', error);
       // Default to free plan if error

--- a/src/lib/resume-storage.ts
+++ b/src/lib/resume-storage.ts
@@ -1,0 +1,56 @@
+const MIME_TYPE_BY_EXTENSION = {
+  pdf: "application/pdf",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+} as const;
+
+export const RESUME_BUCKET = "jobassist";
+
+export type AllowedResumeExtension = keyof typeof MIME_TYPE_BY_EXTENSION;
+
+export const ALLOWED_RESUME_EXTENSIONS = Object.keys(MIME_TYPE_BY_EXTENSION) as AllowedResumeExtension[];
+export const ALLOWED_RESUME_MIME_TYPES = Object.values(MIME_TYPE_BY_EXTENSION);
+
+export const getResumeFileExtension = (file: File): AllowedResumeExtension | undefined => {
+  const parts = file.name.split(".");
+  if (parts.length < 2) {
+    return undefined;
+  }
+  const ext = parts.pop()?.toLowerCase();
+  if (!ext) {
+    return undefined;
+  }
+  return (ALLOWED_RESUME_EXTENSIONS as string[]).includes(ext) ? (ext as AllowedResumeExtension) : undefined;
+};
+
+export const getPreferredResumeMimeType = (file: File): string | undefined => {
+  const extension = getResumeFileExtension(file);
+  if (extension) {
+    return MIME_TYPE_BY_EXTENSION[extension];
+  }
+  if (file.type && ALLOWED_RESUME_MIME_TYPES.includes(file.type)) {
+    return file.type;
+  }
+  return undefined;
+};
+
+export const isValidResumeFile = (file: File): boolean => {
+  const extension = getResumeFileExtension(file);
+  if (extension) {
+    return true;
+  }
+  return file.type ? ALLOWED_RESUME_MIME_TYPES.includes(file.type) : false;
+};
+
+export const normalizeResumeFile = (file: File): File => {
+  const preferredType = getPreferredResumeMimeType(file);
+  if (preferredType && file.type !== preferredType) {
+    return new File([file], file.name, { type: preferredType, lastModified: file.lastModified });
+  }
+  return file;
+};
+
+export const buildResumeStoragePath = (userId: string, file: File): string => {
+  const extension = getResumeFileExtension(file) ?? "pdf";
+  return `resumes/${userId}/${Date.now()}.${extension}`;
+};

--- a/supabase/migrations/20250920120000_update_resume_bucket.sql
+++ b/supabase/migrations/20250920120000_update_resume_bucket.sql
@@ -1,0 +1,33 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM storage.buckets WHERE id = 'jobassist'
+  ) THEN
+    INSERT INTO storage.buckets (id, name, public, allowed_mime_types)
+    VALUES (
+      'jobassist',
+      'jobassist',
+      false,
+      ARRAY[
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      ]
+    );
+  ELSE
+    UPDATE storage.buckets AS b
+    SET allowed_mime_types = (
+      SELECT array_agg(DISTINCT mime_type)
+      FROM (
+        SELECT unnest(coalesce(b.allowed_mime_types, '{}')) AS mime_type
+        UNION
+        SELECT unnest(ARRAY[
+          'application/pdf',
+          'application/msword',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        ])
+      ) AS combined
+    )
+    WHERE b.id = 'jobassist';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a shared resume storage helper to centralize allowed MIME types, normalize files, and build storage paths
- update onboarding and dashboard resume uploads to use the helper and validate file types before calling Supabase
- add a Supabase migration that guarantees the jobassist bucket allows PDF, DOC, and DOCX uploads and tighten dashboard sidebar typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce4dd264d88331bb23d3e623b2818c