### PR TITLE
Handle interest form placeholders consistently

### DIFF
--- a/src/hooks/usePageExitTracking.ts
+++ b/src/hooks/usePageExitTracking.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
+import { EXIT_TRACKING_ABANDONMENT_PLACEHOLDER } from '@/lib/interestForm';
 
 export const usePageExitTracking = (hasCompletedForm: boolean) => {
   const { user } = useAuth();
@@ -17,11 +18,7 @@ export const usePageExitTracking = (hasCompletedForm: boolean) => {
             .insert({
               user_id: user.id,
               email: user.email || '',
-              name: 'Form abandoned',
-              phone: 'N/A',
-              career_objective: 'Form not completed',
-              max_monthly_price: 0,
-              app_expectations: 'Form abandoned before completion'
+              ...EXIT_TRACKING_ABANDONMENT_PLACEHOLDER
             });
         } catch (error) {
           // Silently handle errors during page unload

--- a/src/lib/interestForm.ts
+++ b/src/lib/interestForm.ts
@@ -1,0 +1,100 @@
+export const ABANDONMENT_NAMES = [
+  'user dropped from dialog',
+  'Form abandoned',
+  'Form not completed'
+] as const;
+
+export const DIALOG_ABANDONMENT_PLACEHOLDER = {
+  name: 'user dropped from dialog',
+  phone: '+99999999999',
+  career_objective: '',
+  max_monthly_price: 0,
+  app_expectations: ''
+} as const;
+
+export const EXIT_TRACKING_ABANDONMENT_PLACEHOLDER = {
+  name: 'Form abandoned',
+  phone: 'N/A',
+  career_objective: 'Form not completed',
+  max_monthly_price: 0,
+  app_expectations: 'Form abandoned before completion'
+} as const;
+
+const normalizeString = (value: string) => value.trim().toLowerCase();
+
+const getStringValues = (input: Record<string, unknown>) =>
+  Object.values(input).filter((value): value is string => typeof value === 'string');
+
+const STRING_PLACEHOLDERS = new Set<string>([
+  ...ABANDONMENT_NAMES,
+  ...getStringValues(DIALOG_ABANDONMENT_PLACEHOLDER),
+  ...getStringValues(EXIT_TRACKING_ABANDONMENT_PLACEHOLDER)
+]
+  .map(normalizeString)
+  .filter((value) => value.length > 0));
+
+const NUMBER_PLACEHOLDERS = new Set<number>([
+  DIALOG_ABANDONMENT_PLACEHOLDER.max_monthly_price,
+  EXIT_TRACKING_ABANDONMENT_PLACEHOLDER.max_monthly_price
+]);
+
+export const hasMeaningfulValue = (value?: string | null): boolean => {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return false;
+  }
+
+  return !STRING_PLACEHOLDERS.has(trimmed.toLowerCase());
+};
+
+export interface InterestFormRecord {
+  name?: string | null;
+  phone?: string | null;
+  career_objective?: string | null;
+  max_monthly_price?: number | string | null;
+  app_expectations?: string | null;
+}
+
+const ABANDONMENT_NAME_SET = new Set(ABANDONMENT_NAMES.map(normalizeString));
+
+export const hasCompletedForm = (record?: InterestFormRecord | null): boolean => {
+  if (!record) {
+    return false;
+  }
+
+  const normalizedName = record.name ? normalizeString(record.name) : '';
+  const isAbandonmentName = normalizedName ? ABANDONMENT_NAME_SET.has(normalizedName) : false;
+
+  const hasMeaningfulTextField = [
+    record.name,
+    record.phone,
+    record.career_objective,
+    record.app_expectations
+  ].some(hasMeaningfulValue);
+
+  let hasMeaningfulPrice = false;
+  if (record.max_monthly_price !== undefined && record.max_monthly_price !== null) {
+    const numericValue = typeof record.max_monthly_price === 'string'
+      ? Number(record.max_monthly_price)
+      : record.max_monthly_price;
+
+    if (!Number.isNaN(numericValue) && !NUMBER_PLACEHOLDERS.has(numericValue) && numericValue > 0) {
+      hasMeaningfulPrice = true;
+    }
+  }
+
+  if (!hasMeaningfulTextField && !hasMeaningfulPrice) {
+    return false;
+  }
+
+  if (isAbandonmentName) {
+    return false;
+  }
+
+  return hasMeaningfulTextField || hasMeaningfulPrice;
+};


### PR DESCRIPTION
## Summary
- add a shared interest form utility that centralizes abandonment placeholders and evaluates meaningful submissions
- update the interest form provider and dialog to rely on the shared helpers so abandonment records no longer count as completed forms
- reuse the placeholder constants in the page exit tracker for consistent abandonment writes

## Testing
- npm run build
- node <<'NODE' ... (manual assertions against the compiled interest form helpers)
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7b6ab9948331a1c5164296421fcb