### PR TITLE
Handle resume uploads when metadata columns are missing

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -227,20 +227,32 @@ export type Database = {
       resumes: {
         Row: {
           created_at: string | null
+          file_name: string | null
           file_path: string
+          file_size: number | null
           id: string
+          mime_type: string | null
+          updated_at: string | null
           user_id: string | null
         }
         Insert: {
           created_at?: string | null
+          file_name?: string | null
           file_path: string
+          file_size?: number | null
           id?: string
-          user_id?: string | null
+          mime_type?: string | null
+          updated_at?: string | null
+          user_id: string
         }
         Update: {
           created_at?: string | null
+          file_name?: string | null
           file_path?: string
+          file_size?: number | null
           id?: string
+          mime_type?: string | null
+          updated_at?: string | null
           user_id?: string | null
         }
         Relationships: [

--- a/src/lib/resume-storage.ts
+++ b/src/lib/resume-storage.ts
@@ -1,3 +1,7 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { supabase } from "@/integrations/supabase/client";
+
 const MIME_TYPE_BY_EXTENSION = {
   pdf: "application/pdf",
   doc: "application/msword",
@@ -57,4 +61,61 @@ export const normalizeResumeFile = (file: File): File => {
 export const buildResumeStoragePath = (userId: string, file: File): string => {
   const extension = getResumeFileExtension(file) ?? "pdf";
   return `${userId}/${Date.now()}.${extension}`;
+};
+
+const isMissingResumeMetadataError = (error: PostgrestError | null) => {
+  if (!error) {
+    return false;
+  }
+
+  if (error.code === "42703") {
+    return true;
+  }
+
+  const message = error.message?.toLowerCase() ?? "";
+  return (
+    message.includes("file_name") && message.includes("does not exist")
+  ) || message.includes("column") && message.includes("does not exist");
+};
+
+interface SaveResumeRecordOptions {
+  userId: string;
+  filePath: string;
+  originalFileName: string;
+  fileSize: number;
+  mimeType: string;
+}
+
+export const saveResumeRecord = async ({
+  userId,
+  filePath,
+  originalFileName,
+  fileSize,
+  mimeType,
+}: SaveResumeRecordOptions) => {
+  const metadataPayload = {
+    user_id: userId,
+    file_path: filePath,
+    file_name: originalFileName,
+    file_size: fileSize,
+    mime_type: mimeType,
+  };
+
+  let { data, error } = await supabase
+    .from("resumes")
+    .insert(metadataPayload)
+    .select();
+
+  if (isMissingResumeMetadataError(error)) {
+    console.warn("Resume metadata columns missing, falling back to minimal record", error);
+    ({ data, error } = await supabase
+      .from("resumes")
+      .insert({
+        user_id: userId,
+        file_path: filePath,
+      })
+      .select());
+  }
+
+  return { data, error };
 };


### PR DESCRIPTION
## Summary
- add a shared helper that records resume metadata and falls back when older schemas are still in use
- update resume upload flows to use the helper and improve error handling
- sync the generated Supabase types with the resume metadata columns

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf357c0da48331bca1a26dece1f2d0