### PR TITLE
Improve onboarding flow, dashboard UI, and job fetch integration

### DIFF
--- a/src/components/InterestFormDialog.tsx
+++ b/src/components/InterestFormDialog.tsx
@@ -8,13 +8,13 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
-import { useNavigate } from "react-router-dom";
 import { usePageExitTracking } from "@/hooks/usePageExitTracking";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { useState, useCallback } from "react";
 import { DIALOG_ABANDONMENT_PLACEHOLDER, hasCompletedForm } from "@/lib/interestForm";
+import { useOnboarding } from "@/contexts/OnboardingContext";
 
 const formSchema = z.object({
   name: z.string().optional().default(""),
@@ -34,10 +34,10 @@ interface InterestFormDialogProps {
 const InterestFormDialog = ({ open, onOpenChange }: InterestFormDialogProps) => {
   const { user } = useAuth();
   const { toast } = useToast();
-  const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasInteracted, setHasInteracted] = useState(false);
   const [hasCompleted, setHasCompleted] = useState(false);
+  const { completeStep } = useOnboarding();
   
   usePageExitTracking(hasCompleted);
 
@@ -154,11 +154,11 @@ const InterestFormDialog = ({ open, onOpenChange }: InterestFormDialogProps) => 
       setHasCompleted(true);
       toast({
         title: "Thank you!",
-        description: "Now let's choose the perfect plan for your job search.",
+        description: "Next, upload your CV so we can tailor your matches.",
       });
 
       onOpenChange(false);
-      navigate('/plan-selection');
+      completeStep('interest');
     } catch (error) {
       console.error('❌ Error submitting form:', error);
       toast({
@@ -169,7 +169,7 @@ const InterestFormDialog = ({ open, onOpenChange }: InterestFormDialogProps) => 
     } finally {
       setIsSubmitting(false);
     }
-  }, [user, toast, navigate, onOpenChange]);
+  }, [user, toast, onOpenChange, completeStep]);
 
   const handleInputInteraction = useCallback(() => {
     if (!hasInteracted) {

--- a/src/components/dashboard/PremiumDashboardLayout.tsx
+++ b/src/components/dashboard/PremiumDashboardLayout.tsx
@@ -2,15 +2,15 @@ import { ReactNode } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Navigate } from "react-router-dom";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { PremiumHeader } from "./PremiumHeader";
 import { PremiumSidebar } from "./PremiumSidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface PremiumDashboardLayoutProps {
   children: ReactNode;
+  userPlan?: string | null;
 }
 
-export const PremiumDashboardLayout = ({ children }: PremiumDashboardLayoutProps) => {
+export const PremiumDashboardLayout = ({ children, userPlan }: PremiumDashboardLayoutProps) => {
   const { user, loading } = useAuth();
 
   if (loading) {
@@ -57,12 +57,10 @@ export const PremiumDashboardLayout = ({ children }: PremiumDashboardLayoutProps
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[1000px] h-[1000px] bg-gradient-radial from-primary/3 via-transparent to-transparent rounded-full blur-3xl"></div>
         </div>
         
-        <PremiumSidebar />
-        
+        <PremiumSidebar userPlan={userPlan} />
+
         <div className="flex-1 flex flex-col min-h-screen">
-          <PremiumHeader />
-          
-          <main className="flex-1 overflow-auto">
+          <main className="flex-1 overflow-auto pt-20 lg:pt-24">
             <div className="content-wrapper min-h-full">
               <div className="animate-fade-in-up">
                 {children}

--- a/src/components/dashboard/PremiumJobsTable.tsx
+++ b/src/components/dashboard/PremiumJobsTable.tsx
@@ -245,6 +245,19 @@ export const PremiumJobsTable = ({ userPlan, searchQuery }: PremiumJobsTableProp
   }, [planLimits.resumeVariants, userPlan])
   const shouldShowMaskedRows = jobs.length > visibleRows;
 
+  const planLabel = useMemo(() => {
+    const normalized = userPlan?.toLowerCase() || 'free';
+    switch (normalized) {
+      case 'elite':
+        return 'Elite';
+      case 'pro':
+      case 'premium':
+        return 'Pro';
+      default:
+        return 'Free';
+    }
+  }, [userPlan])
+
   if (loading) {
     return (
       <Card className="border-border/50 backdrop-blur-sm bg-gradient-card">
@@ -293,7 +306,7 @@ export const PremiumJobsTable = ({ userPlan, searchQuery }: PremiumJobsTableProp
                   Job Opportunities
                 </CardTitle>
                 <p className="text-sm text-muted-foreground mt-1">
-                  {jobs.length} matches found • {visibleRows} visible on {userPlan} plan
+                  {jobs.length} matches found • {visibleRows} visible on {planLabel} plan
                 </p>
               </div>
             </div>

--- a/src/components/dashboard/PremiumSidebar.tsx
+++ b/src/components/dashboard/PremiumSidebar.tsx
@@ -1,20 +1,18 @@
-import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSidebar } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
-import { 
+import {
   Home,
-  LayoutDashboard, 
-  Briefcase, 
-  FileText, 
-  BarChart3, 
-  Settings, 
+  LayoutDashboard,
+  Briefcase,
+  FileText,
+  BarChart3,
+  Settings,
   Crown,
   Zap,
   Target,
   Calendar,
-  MessageSquare,
-  Sparkles
+  MessageSquare
 } from "lucide-react";
 import jobvanceIcon from "@/assets/jobvance-icon.png";
 import {
@@ -32,6 +30,24 @@ import {
 import { Button } from "@/components/ui/button";
 import { CVManager } from "./CVManager";
 import { Link } from "react-router-dom";
+import { usePlanLimits } from "@/hooks/usePlanLimits";
+
+interface PremiumSidebarProps {
+  userPlan?: string | null;
+}
+
+const formatPlanName = (plan?: string | null) => {
+  const normalized = plan?.toLowerCase() || 'free';
+  switch (normalized) {
+    case 'elite':
+      return 'Elite Plan';
+    case 'pro':
+    case 'premium':
+      return 'Pro Plan';
+    default:
+      return 'Free Plan';
+  }
+};
 
 const navigationItems = [
   {
@@ -84,11 +100,14 @@ const navigationItems = [
   },
 ];
 
-export const PremiumSidebar = () => {
-  const { state, isMobile } = useSidebar();
+export const PremiumSidebar = ({ userPlan }: PremiumSidebarProps) => {
+  const { state } = useSidebar();
   const isCollapsed = state === "collapsed";
   const location = useLocation();
   const navigate = useNavigate();
+  const normalizedPlanRaw = (userPlan ?? 'free').toLowerCase();
+  const normalizedPlan = normalizedPlanRaw === 'premium' ? 'pro' : normalizedPlanRaw;
+  const planLimits = usePlanLimits(normalizedPlan);
 
   return (
     <Sidebar collapsible="icon" className="border-r border-border/10 bg-card/30 backdrop-blur-sm">
@@ -155,7 +174,7 @@ export const PremiumSidebar = () => {
               Quick Actions
             </SidebarGroupLabel>
             <div className="space-y-4">
-              <CVManager userPlan="premium" />
+              <CVManager userPlan={normalizedPlan} />
             </div>
           </SidebarGroup>
         )}
@@ -168,30 +187,29 @@ export const PremiumSidebar = () => {
             <div className="space-y-4">
               <div className="premium-card p-4 bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
                 <div className="flex items-center justify-between mb-3">
-                  <span className="text-sm font-semibold text-foreground">Premium Plan</span>
+                  <span className="text-sm font-semibold text-foreground">{formatPlanName(userPlan)}</span>
                   <Crown className="h-5 w-5 text-warning" />
                 </div>
-                <div className="space-y-3">
-                  <div>
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="text-xs font-medium text-muted-foreground">Job Applications</span>
-                      <span className="text-xs font-semibold text-foreground">150/200</span>
-                    </div>
-                    <div className="w-full bg-muted/50 rounded-full h-2">
-                      <div className="bg-gradient-to-r from-primary to-primary-hover h-2 rounded-full transition-all duration-500" style={{ width: '75%' }}></div>
-                    </div>
+                <div className="space-y-3 text-xs text-muted-foreground">
+                  <div className="flex items-center justify-between">
+                    <span>Daily job fetches</span>
+                    <span className="font-semibold text-foreground">{planLimits.dailyJobApplications}</span>
                   </div>
-                  
-                  <div>
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="text-xs font-medium text-muted-foreground">AI Resumes</span>
-                      <span className="text-xs font-semibold text-foreground">12/20</span>
-                    </div>
-                    <div className="w-full bg-muted/50 rounded-full h-2">
-                      <div className="bg-gradient-to-r from-success to-info h-2 rounded-full transition-all duration-500" style={{ width: '60%' }}></div>
-                    </div>
+                  <div className="flex items-center justify-between">
+                    <span>CV uploads</span>
+                    <span className="font-semibold text-foreground">{planLimits.resumeVariants}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Plan tier</span>
+                    <span className="font-semibold text-foreground capitalize">{normalizedPlan}</span>
                   </div>
                 </div>
+                {normalizedPlan === 'free' && (
+                  <Button size="sm" className="w-full mt-4 bg-gradient-primary hover:opacity-90" onClick={() => navigate('/pricing')}>
+                    <Zap className="h-3 w-3 mr-2" />
+                    Upgrade Plan
+                  </Button>
+                )}
               </div>
             </div>
           </SidebarGroup>

--- a/src/components/onboarding/JobPreferencesDialog.tsx
+++ b/src/components/onboarding/JobPreferencesDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -59,6 +59,36 @@ export const JobPreferencesDialog = ({ open, onSuccess }: JobPreferencesDialogPr
   const [saving, setSaving] = useState(false);
   const { user } = useAuth();
   const { toast } = useToast();
+
+  useEffect(() => {
+    const loadExistingPreferences = async () => {
+      if (!open || !user) {
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from('preferences')
+        .select('location, job_title, seniority_level, job_type, job_posting_type, job_posting_date')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (error) {
+        console.error('Error loading job preferences:', error);
+        return;
+      }
+
+      if (data) {
+        setPreferences((prev) => ({
+          ...prev,
+          ...Object.fromEntries(
+            Object.entries(data).map(([key, value]) => [key, value ?? ''])
+          )
+        }));
+      }
+    };
+
+    loadExistingPreferences();
+  }, [open, user]);
 
   const handleSave = async () => {
     if (!user) return;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,22 +36,12 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-4 sm:p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         "max-h-[90vh] overflow-y-auto",
-        "mx-4 sm:mx-0", // Add horizontal margin on mobile
-        "w-[calc(100vw-2rem)] sm:w-full", // Full width on mobile with margins
+        "mx-4 sm:mx-0",
+        "w-[calc(100vw-2rem)] sm:w-full",
         className
       )}
-      style={{
-        position: 'fixed !important',
-        left: '50% !important',
-        top: '50% !important',
-        transform: 'translate(-50%, -50%) !important',
-        zIndex: 9999,
-        margin: '0 !important',
-        maxHeight: '90vh',
-        overflowY: 'auto'
-      }}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- center the shared dialog component so onboarding modals are positioned correctly on any viewport
- extend the onboarding context and interest form handling to require interest, resume, and preference steps before loading the dashboard, including prefilling saved data
- align the dashboard layout and header with the marketing nav, surface the current plan consistently, and remove the redundant search bar while normalising plan features
- send full job preference and CV data when triggering the job fetch edge function and update the function to forward the payload to Make.com

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f712803483319f583a06b6c839f1