### PR TITLE
Remove inline dialog centering styles

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -42,14 +42,6 @@ const DialogContent = React.forwardRef<
         "mx-auto my-auto",
         className
       )}
-      style={{
-        position: 'fixed',
-        left: '50%',
-        top: '50%',
-        transform: 'translate(-50%, -50%) !important',
-        zIndex: 9999,
-        margin: 'auto'
-      }}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- remove the inline centering transform from the dialog component so Tailwind classes control layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83636587883319316de48a58e912c